### PR TITLE
Encoding error handling

### DIFF
--- a/fluent-plugin-redis-store-gabfl.gemspec
+++ b/fluent-plugin-redis-store-gabfl.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |gem|
     gem.name        = "fluent-plugin-redis-store-gabfl"
     gem.email       = "pypi@gab.lc"
-    gem.version     = "0.1.2"
+    gem.version     = "0.1.3"
     gem.authors     = ["moaikids", "HANAI Tohru aka pokehanai", "Gabriel Bordeaux"]
     gem.licenses    = ["Apache License Version 2.0"]
     gem.summary     = %q{Redis(zset/set/list/string/publish) output plugin for Fluentd}

--- a/lib/fluent/plugin/out_redis_store.rb
+++ b/lib/fluent/plugin/out_redis_store.rb
@@ -30,6 +30,7 @@ module Fluent
       super
       require 'redis'
       require 'msgpack'
+      require 'logger'
     end
 
     def configure(conf)
@@ -49,6 +50,8 @@ module Fluent
         @redis = Redis.new(:host => @host, :port => @port, :password => @password,
                            :timeout => @timeout, :thread_safe => true, :db => @db)
       end
+
+      @logger = Logger.new('/var/log/td-agent/fluentd_outredis.log')
     end
 
     def shutdown
@@ -79,6 +82,10 @@ module Fluent
                   operation_for_publish(record)
                 end
               rescue NoMethodError => e
+                puts e
+              rescue Encoding::UndefinedConversionError => e
+                @logger.error  { "Plugin error: " + e.to_s }
+                @logger.error  { "Original record: " + record.to_s }
                 puts e
               end
             }


### PR DESCRIPTION
To address http://docs.fluentd.org/v0.12/articles/faq#i-got-enconding-error-inside-plugin-how-to-fix-it

The following plugin should be installed to handle UTF-8 data: https://github.com/repeatedly/fluent-plugin-record-modifier#char_encoding

This PR will avoid a fluentd crash if the data is not encoded correctly and creates a unicode error